### PR TITLE
[fix]WAMの抽選時、floatの丸めによってOutOfIndexを起こす問題を修正

### DIFF
--- a/Runtime/WAM.cs
+++ b/Runtime/WAM.cs
@@ -104,7 +104,7 @@ namespace KoheiUtils
         {
             if (random is not null)
             {
-                float r = (float) random.NextDouble() * p.Length;
+                double r = random.NextDouble() * p.Length;
                 int   i = (int) Math.Floor(r);
                 r -= i;
 


### PR DESCRIPTION
random.NextDouble()が一定値以上（約0.99999998）の場合、floatに変換される際に1に丸められてしまうのを修正しました。